### PR TITLE
Update version for G-release upstream

### DIFF
--- a/miq_version/__init__.py
+++ b/miq_version/__init__.py
@@ -97,7 +97,7 @@ class Version(object):
         try:
             if not isinstance(other, type(self)):
                 other = Version(other)
-        except:
+        except Exception:
             raise ValueError('Cannot compare Version to {}'.format(type(other).__name__))
 
         if self == other:
@@ -128,7 +128,7 @@ class Version(object):
         try:
             if not isinstance(other, type(self)):
                 other = Version(other)
-        except:
+        except Exception:
             raise ValueError('Cannot compare Version to {}'.format(type(other).__name__))
 
         if self == other:
@@ -161,7 +161,7 @@ class Version(object):
                 other = Version(other)
             return (
                 self.version == other.version and self.normalized_suffix == other.normalized_suffix)
-        except:
+        except Exception:
             return False
 
     def __contains__(self, ver):
@@ -176,7 +176,7 @@ class Version(object):
         """
         try:
             return Version(ver).is_in_series(self)
-        except:
+        except Exception:
             return False
 
     def is_in_series(self, series):

--- a/miq_version/__init__.py
+++ b/miq_version/__init__.py
@@ -31,6 +31,13 @@ class Version(object):
                 'euwe' in vstring,
                 'gaprindashvili' in vstring]):
             vstring = 'master'
+        # TODO These aren't used anywhere - remove?
+        if vstring == 'darga-3':
+            vstring = '5.6.1'
+        if vstring == 'darga-4.1':
+            vstring = '5.6.2'
+        if vstring == 'darga-5':
+            vstring = '5.6.3'
 
         components = list(filter(lambda x: x and x != '.',
                             self.component_re.findall(vstring)))

--- a/miq_version/__init__.py
+++ b/miq_version/__init__.py
@@ -24,15 +24,13 @@ class Version(object):
             vstring = ".".join(map(str, vstring))
         elif vstring:
             vstring = str(vstring).strip()
-        if vstring in ('master', 'latest', 'upstream') or 'fine' in vstring or 'euwe' in vstring:
+        # TODO separate upstream versions
+        if any([
+                vstring in ('master', 'latest', 'upstream'),
+                'fine' in vstring,
+                'euwe' in vstring,
+                'gaprindashvili' in vstring]):
             vstring = 'master'
-        # TODO These aren't used anywhere - remove?
-        if vstring == 'darga-3':
-            vstring = '5.6.1'
-        if vstring == 'darga-4.1':
-            vstring = '5.6.2'
-        if vstring == 'darga-5':
-            vstring = '5.6.3'
 
         components = list(filter(lambda x: x and x != '.',
                             self.component_re.findall(vstring)))


### PR DESCRIPTION
Add support for upstream 'G' release, gaprindashvili.

Change up the logic a bit to read better with the multitude of upstream releases.

Remove old 'darga' mapping that had TODO

TravisCI failure in py2.7 has to do with bare excepts that I didn't add here.