### PR TITLE
[RFR] Add TemplateName and clsmethods

### DIFF
--- a/miq_version/__init__.py
+++ b/miq_version/__init__.py
@@ -1,8 +1,13 @@
 import re
+from datetime import date, datetime
+
+import attr
+import requests
 from cached_property import cached_property
 from collections import namedtuple
-from six import string_types
 from functools import total_ordering
+from lxml import html
+from six import string_types
 
 
 @total_ordering
@@ -210,17 +215,204 @@ LOWEST = Version.lowest()
 LATEST = Version.latest()
 UPSTREAM = LATEST
 
-SPTuple = namedtuple('StreamProductTuple', ['stream', 'product_version'])
+SPTuple = namedtuple('StreamProductTuple', ['stream', 'product_version', 'template_regex'])
+TemplateInfo = namedtuple('TemplateInfo', ['group_name', 'datestamp', 'stream', 'version'])
+
 
 # Maps stream and product version to each app version
 version_stream_product_mapping = {
-    '5.2': SPTuple('downstream-52z', '3.0'),
-    '5.3': SPTuple('downstream-53z', '3.1'),
-    '5.4': SPTuple('downstream-54z', '3.2'),
-    '5.5': SPTuple('downstream-55z', '4.0'),
-    '5.6': SPTuple('downstream-56z', '4.1'),
-    '5.7': SPTuple('downstream-57z', '4.2'),
-    '5.8': SPTuple('downstream-58z', '4.5'),
-    '5.9': SPTuple('downstream-59z', '4.6'),
-    LATEST: SPTuple('upstream', 'master')
+    '5.2': SPTuple('downstream-52z', '3.0', [
+        r'^cfme-(?P<ver>52\d{3})-(?P<year>\d{4})?(?P<month>\d{2})(?P<day>\d{2})']),
+    '5.3': SPTuple('downstream-53z', '3.1', [
+        r'^cfme-(?P<ver>53\d{3})-(?P<year>\d{4})?(?P<month>\d{2})(?P<day>\d{2})']),
+    '5.4': SPTuple('downstream-54z', '3.2', [
+        r'^cfme-(?P<ver>54\d{3})-(?P<year>\d{4})?(?P<month>\d{2})(?P<day>\d{2})']),
+    '5.5': SPTuple('downstream-55z', '4.0', [
+        r'^cfme-(?P<ver>55\d{3})-(?P<year>\d{4})?(?P<month>\d{2})(?P<day>\d{2})']),
+    '5.6': SPTuple('downstream-56z', '4.1', [
+        r'^cfme-(?P<ver>56\d{3})-(?P<year>\d{4})?(?P<month>\d{2})(?P<day>\d{2})']),
+    '5.7': SPTuple('downstream-57z', '4.2', [
+        r'^cfme-(?P<ver>57\d{3})-(?P<year>\d{4})?(?P<month>\d{2})(?P<day>\d{2})']),
+    '5.8': SPTuple('downstream-58z', '4.5', [
+        r'^cfme-(?P<ver>58\d{3})-(?P<year>\d{4})?(?P<month>\d{2})(?P<day>\d{2})']),
+    '5.9': SPTuple('downstream-59z', '4.6', [
+        r'^cfme-(?P<ver>59\d{3})-(?P<year>\d{4})?(?P<month>\d{2})(?P<day>\d{2})']),
+    'euwe': SPTuple('upstream-euwe', 'master', [
+        r'^miq-(?P<ver>euwe[-\w]*?)-(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2})',
+        r'^miq-stable-(?P<ver>euwe[-\w]*?)-(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2})']),
+    'fine': SPTuple('upstream-fine', 'master', [
+        r'^miq-(?P<ver>fine[-\w]*?)-(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2})',
+        r'^miq-stable-(?P<ver>fine[-\w]*?)-(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2})']),
+    'gap': SPTuple('upstream-gap', 'master', [
+        r'^miq-(?P<ver>gapri[-\w]*?)-(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2})',
+        r'^miq-stable-(?P<ver>gapri[-\w]*?)-(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2})']),
+    LATEST: SPTuple('upstream', 'master', [
+        r'miq-nightly-(?P<ver>(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2}))',
+        r'miq-(?P<ver>(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2}))'])
 }
+
+# maps some service templates
+generic_matchers = (
+    ('sprout', r'^s_tpl'),
+    ('sprout', r'^sprout_template'),
+    ('rhevm-internal', r'^raw'),
+)
+
+
+def futurecheck(check_date):
+    """Given a date object, return a date object that isn't from the future
+
+    Some templates only have month/day values, not years. We create a date object
+
+    """
+    today = date.today()
+    while check_date > today:
+        check_date = date(check_date.year - 1, check_date.month, check_date.day)
+
+    return check_date
+
+
+@attr.s
+class TemplateName(object):
+    """Generate a template name from given link, using build timestamp
+
+    This method should handle naming templates from the following URL types:
+
+    - http://<build-server-address>/builds/manageiq/master/latest/
+    - http://<build-server-address>/builds/manageiq/gaprindashvili/stable/
+    - http://<build-server-address>/builds/manageiq/fine/stable/
+    - http://<build-server-address>/builds/cfme/5.8/stable/
+    - http://<build-server-address>/builds/cfme/5.9/latest/
+
+    These builds fall into a few categories:
+
+    - MIQ nightly (master/latest)  (upstream)
+    - MIQ stable (<name>/stable)  (upstream_gap, upstream_fine, etc)
+    - CFME nightly (<stream>/latest)  (downstream-nightly)
+    - CFME stream (<stream>/stable)  (downstream-<stream>)
+
+    The generated template names should follow the syntax with 5 digit version numbers:
+
+    - MIQ nightly: miq-nightly-<yyyymmdd>  (miq-nightly-201711212330)
+    - MIQ stable: miq-<name>-<number>-yyyymmdd  (miq-fine-4-20171024, miq-gapri-20180130)
+    - CFME stream: cfme-<version>-<yyyymmdd>  (cfme-57402-20171202)
+
+    Release names for upstream will be truncated to 5 letters (thanks gaprindashvili...)
+    """
+    SHA = 'SHA256SUM'
+    CFME_ID = 'cfme'
+    MIQ_ID = 'manageiq'
+    build_url = attr.ib()  # URL to the build folder with ova/vhd/qc2/etc images
+
+    @property
+    def build_version(self):
+        """Version string from version file in build folder (cfme)
+        release name and build number from an image file (MIQ)
+
+        Will substitute 'nightly' for master URLs
+
+        Raises:
+            ValueError if unable to parse version string or release name from files
+
+        Returns:
+            String 5-digit version number or release name for MIQ
+        """
+        v = requests.get('/'.join([self.build_url, 'version']))
+        if v.ok:
+            match = re.search(
+                '^(?P<major>\d)\.?(?P<minor>\d)\.?(?P<patch>\d)\.?(?P<build>\d{1,2})',
+                v.content)
+            if match:
+                return ''.join([match.group('major'),
+                                match.group('minor'),
+                                match.group('patch'),
+                                match.group('build').zfill(2)])  # zero left-pad
+            else:
+                raise ValueError('Unable to match version string in %s/version: {}'
+                                 .format(self.build_url, v.content))
+        else:
+            build_dir = requests.get(self.build_url)
+            link_parser = html.fromstring(build_dir.content)
+            # Find image file links, use first one to pattern match name
+            # iterlinks returns tuple of (element, attribute, link, position)
+            images = [l
+                      for _, a, l, _ in link_parser.iterlinks()
+                      if a == 'href' and l.endswith('.ova') or l.endswith('.vhd')]
+            if images:
+                # pull release and its possible number (with -) from image string
+                # examples: miq-prov-fine-4-date-hash.vhd, miq-prov-gaprindashvilli-date-hash.vhd
+                match = re.search(
+                    'manageiq-(?:[\w]+?)-(?P<release>[\w]+?)(?P<number>-\d)?-\d{''3,}',
+                    str(images[0]))
+                if match:
+                    # if its a master image, version is 'nightly', otherwise use release+number
+                    return ('nightly'
+                            if 'master' in match.group('release')
+                            else '{}{}'.format(match.group('release')[:5], match.group('number')))
+                else:
+                    raise ValueError('Unable to match version string in image file: {}'
+                                     .format(images[0]))
+            else:
+                raise ValueError('No image of ova or vhd type found to parse version from in {}'
+                                 .format(self.build_url))
+
+    @property
+    def build_date(self):
+        """Get a build date from the SHA256SUM"""
+        r = requests.get('/'.join([self.build_url, self.SHA]))
+        if r.ok:
+            timestamp = datetime.strptime(r.headers.get('Last-Modified'),
+                                          "%a, %d %b %Y %H:%M:%S %Z")
+            return timestamp.strftime('%Y%m%d')
+        else:
+            raise ValueError('{} file not found in {}'.format(self.SHA, self.build_url))
+
+    @property
+    def template_name(self):
+        """Actually construct the template name"""
+        return '-'.join([self.CFME_ID if self.CFME_ID in self.build_url else self.MIQ_ID,
+                         self.build_version,
+                         self.build_date])
+
+    @classmethod
+    def parse_template(cls, template_name):
+        """Given a template name, attempt to extract its group name and upload date
+
+            Returns:
+                * None if no groups matched
+                * group_name, datestamp of the first matching group. group name will be a string,
+                  datestamp with be a :py:class:`datetime.date <python:datetime.date>`, or None if
+                  a date can't be derived from the template name
+            """
+        for stream_tuple in version_stream_product_mapping.values():
+            for regex in stream_tuple.template_regex:
+                matches = re.match(regex, template_name)
+                if matches:
+                    groups = matches.groupdict()
+                    # hilarity may ensue if this code is run right before the new year
+                    today = date.today()
+                    year = int(groups.get('year', today.year))
+                    month, day = int(groups['month']), int(groups['day'])
+                    version = groups.get('ver')
+                    # validate the template date by turning into a date obj
+                    try:
+                        # year, month, day might have been parsed incorrectly with loose regex
+                        template_date = futurecheck(date(year, month, day))
+                    except ValueError:
+                        continue
+                    dot_version = (version if 'downstream' not in stream_tuple.stream else
+                                   '{}.{}.{}.{}'.format(version[0],
+                                                        version[1],
+                                                        version[2],
+                                                        version[3:]))
+
+                    return TemplateInfo(stream_tuple.stream,
+                                        template_date,
+                                        True,
+                                        version=dot_version)
+        for group_name, regex in generic_matchers:
+            matches = re.match(regex, template_name)
+            if matches:
+                return TemplateInfo(group_name, None, False, None)
+        # If no match, unknown
+        return TemplateInfo('unknown', None, False, None)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 cached_property
+lxml
 six

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import pytest
 
-from miq_version import Version
+from miq_version import Version, TemplateName
 
 version_list = [
     Version('5.7.0.0'),
@@ -105,8 +105,7 @@ EQ = '=='
     ('1.2.3.4-beta', LT, '1.2.3.4'),
     ('1.2.3.4-beta1', GT, '1.2.3.4-beta'),
     ('1.2.3.4-beta1.1', GT, '1.2.3.4-beta1'),
-    ('1.2.3.4-alpha-nightly', GT, '1.2.3.4-alpha'),     # TODO: This one might be discussed
-])
+    ('1.2.3.4-alpha-nightly', GT, '1.2.3.4-alpha')])  # TODO: This one might be discussed
 def test_version(v1, op, v2):
     v1 = Version(v1)
     v2 = Version(v2)
@@ -127,3 +126,11 @@ def test_version(v1, op, v2):
 
 def test_version_list():
     assert sorted(version_list, reverse=True) == reverse_sorted_version
+
+
+@pytest.mark.parametrize(('tmp_name', 'ver_string'),
+                         [('miq-nightly-20180531', '20180531'),
+                          ('miq-fine-3-20171215', 'fine-3'),
+                          ('cfme-58403-20180220', '5.8.4.03')])
+def test_template_parsing(tmp_name, ver_string):
+    assert TemplateName.parse_template(tmp_name).version == ver_string


### PR DESCRIPTION
TemplateName for generating template name from build URL
classmethods for parsing the version, and other template info, from a name

Providing needs for trackerbot, sprout, and other tooling in a central location

Most of this is pulled from existing ManageIQ/integration_test modules and modified

Not sure why py2.7 failed in travis, other py versions passed.