### PR TITLE
Add type field to TemplateName for ova/qcow, paravirtual, etc

### DIFF
--- a/miq_version/__init__.py
+++ b/miq_version/__init__.py
@@ -216,94 +216,72 @@ LATEST = Version.latest()
 UPSTREAM = LATEST
 
 SPTuple = namedtuple('StreamProductTuple', ['stream', 'product_version', 'template_regex'])
-TemplateInfo = namedtuple('TemplateInfo', ['group_name', 'datestamp', 'stream', 'version'])
+TemplateInfo = namedtuple('TemplateInfo', ['group_name', 'datestamp', 'stream', 'version', 'type'])
 
+FORMATS_DOWNSTREAM = {
+    # Looks like: cfme-5.9.3.4-20180531 or cfme-5.10.0.0-pv-20171231
+    'template_with_year':
+        '^cfme-(?P<ver>(?P<major>{major})\.(?P<minor>{minor})\.(?P<patch>\d)\.(?P<build>\d{{1,2}}))'
+        '-((?P<type>[\w]*)-)?(?P<year>\d{{4}})?(?P<month>\d{{2}})(?P<day>\d{{2}})',
+    # Looks like: cfme-59304-0131
+    'template_no_year':
+        '^cfme-(?P<ver>{major}{minor}\d+)-(?P<month>\d{{2}})(?P<day>\d{{2}})',
+    # Looks like: docker-5.8.10.1-20180229
+    'template_docker':
+        '^docker-'
+        '(?P<ver>(?P<major>{major})\.?(?P<minor>{minor})\.?(?P<patch>\d)\.?(?P<build>\d{{1,2}}))'
+        '-(?P<year>\d{{4}})?(?P<month>\d{{2}})(?P<day>\d{{2}})',
+    # Looks like: s_tpl_downstream_59z_20171001 or s-appl-downstream-57z-20161231
+    'sprout':
+        '^s(-|_)(appl|tpl)(-|_)downstream(-|_)(?P<ver>{major}{minor})z'
+        '(-|_)(?P<year>\d{{2}})?(?P<month>\d{{2}})(?P<day>\d{{2}})',
+}
+FORMATS_UPSTREAM = {
+    # Looks like: miq-fine-20180531 or miq-euwe-2-20171231
+    'upstream_with_year':
+        '^miq-(?P<ver>{stream}[-\w]*?)-(?P<year>\d{{4}})(?P<month>\d{{2}})(?P<day>\d{{2}})',
+    # Looks like: miq-stable-fine-4-20180315
+    'upstream_stable':
+        '^miq-stable-(?P<ver>{stream}[-\w]*?)-(?P<year>\d{{4}})(?P<month>\d{{2}})(?P<day>\d{{2}})',
+    # Looks like: s_tpl_upstream_fine-3_20171028 or s-appl-upstream-gapri-20180411
+    'upstream_sprout':
+        '^s(-|_)(appl|tpl)(-|_)upstream(-|_)(?P<ver>{stream}[-\w]*?)'
+        '(-|_)(?P<year>\d{{2}})(?P<month>\d{{2}})(?P<day>\d{{2}})'
+}
 
 # Maps stream and product version to each app version
 version_stream_product_mapping = {
-    '5.2': SPTuple('downstream-52z', '3.0', [
-        r'^cfme-(?P<ver>52\d{3})-(?P<year>\d{4})?(?P<month>\d{2})(?P<day>\d{2})',
-        r'^cfme-(?P<ver>52\d+)-(?P<month>\d{2})(?P<day>\d{2})',
-        r'^docker-(?P<ver>52\d+)-(?P<year>\d{4})?(?P<month>\d{2})(?P<day>\d{2})',
-        r'^s(-|_)(appl|tpl)(-|_)downstream(-|_)(?P<ver>52)z(-|_)(?P<year>\d{2})?'
-        r'(?P<month>\d{2})(?P<day>\d{2})']),
-    '5.3': SPTuple('downstream-53z', '3.1', [
-        r'^cfme-(?P<ver>53\d{3})-(?P<year>\d{4})?(?P<month>\d{2})(?P<day>\d{2})',
-        r'^cfme-(?P<ver>53\d+)-(?P<month>\d{2})(?P<day>\d{2})',
-        r'^docker-(?P<ver>53\d+)-(?P<year>\d{4})?(?P<month>\d{2})(?P<day>\d{2})',
-        r'^s(-|_)(appl|tpl)(-|_)downstream(-|_)(?P<ver>53)z(-|_)(?P<year>\d{2})?'
-        r'(?P<month>\d{2})(?P<day>\d{2})']),
-    '5.4': SPTuple('downstream-54z', '3.2', [
-        r'^cfme-(?P<ver>54\d{3})-(?P<year>\d{4})?(?P<month>\d{2})(?P<day>\d{2})',
-        r'^cfme-(?P<ver>54\d+)-(?P<month>\d{2})(?P<day>\d{2})',
-        r'^docker-(?P<ver>54\d+)-(?P<year>\d{4})?(?P<month>\d{2})(?P<day>\d{2})',
-        r'^s(-|_)(appl|tpl)(-|_)downstream(-|_)(?P<ver>54)z(-|_)(?P<year>\d{2})?'
-        r'(?P<month>\d{2})(?P<day>\d{2})']),
-    '5.5': SPTuple('downstream-55z', '4.0', [
-        r'^cfme-(?P<ver>55\d{3})-(?P<year>\d{4})?(?P<month>\d{2})(?P<day>\d{2})',
-        r'^cfme-(?P<ver>55\d+)-(?P<month>\d{2})(?P<day>\d{2})',
-        r'^docker-(?P<ver>55\d+)-(?P<year>\d{4})?(?P<month>\d{2})(?P<day>\d{2})',
-        r'^s(-|_)(appl|tpl)(-|_)downstream(-|_)(?P<ver>55)z(-|_)(?P<year>\d{2})?'
-        r'(?P<month>\d{2})(?P<day>\d{2})']),
-    '5.6': SPTuple('downstream-56z', '4.1', [
-        r'^cfme-(?P<ver>56\d{3})-(?P<year>\d{4})?(?P<month>\d{2})(?P<day>\d{2})',
-        r'^cfme-nightly-(?P<ver>56\d+)-(?P<year>\d{4})?(?P<month>\d{2})(?P<day>\d{2})',
-        r'^cfme-(?P<ver>56\d+)-(?P<month>\d{2})(?P<day>\d{2})',
-        r'^docker-(?P<ver>56\d+)-(?P<year>\d{4})?(?P<month>\d{2})(?P<day>\d{2})',
-        r'^s(-|_)(appl|tpl)(-|_)downstream(-|_)(?P<ver>56)z(-|_)(?P<year>\d{2})?'
-        r'(?P<month>\d{2})(?P<day>\d{2})']),
-    '5.7': SPTuple('downstream-57z', '4.2', [
-        r'^cfme-(?P<ver>57\d{3})-(?P<year>\d{4})?(?P<month>\d{2})(?P<day>\d{2})',
-        r'^cfme-nightly-(?P<ver>57\d+)-(?P<year>\d{4})?(?P<month>\d{2})(?P<day>\d{2})',
-        r'^cfme-(?P<ver>57\d+)-(?P<month>\d{2})(?P<day>\d{2})',
-        r'^docker-(?P<ver>57\d+)-(?P<year>\d{4})?(?P<month>\d{2})(?P<day>\d{2})',
-        r'^s(-|_)(appl|tpl)(-|_)downstream(-|_)(?P<ver>57)z(-|_)(?P<year>\d{2})?'
-        r'(?P<month>\d{2})(?P<day>\d{2})']),
-    '5.8': SPTuple('downstream-58z', '4.5', [
-        r'^cfme-(?P<ver>58\d{3})-(?P<year>\d{4})?(?P<month>\d{2})(?P<day>\d{2})',
-        r'^cfme-nightly-(?P<ver>58\d+)-(?P<year>\d{4})?(?P<month>\d{2})(?P<day>\d{2})',
-        r'^cfme-(?P<ver>58\d+)-(?P<month>\d{2})(?P<day>\d{2})',
-        r'^docker-(?P<ver>58\d+)-(?P<year>\d{4})?(?P<month>\d{2})(?P<day>\d{2})',
-        r'^s(-|_)(appl|tpl)(-|_)downstream(-|_)(?P<ver>58)z(-|_)(?P<year>\d{2})?'
-        r'(?P<month>\d{2})(?P<day>\d{2})']),
-    '5.9': SPTuple('downstream-59z', '4.6', [
-        r'^cfme-(?P<ver>59\d{3})-(?P<year>\d{4})?(?P<month>\d{2})(?P<day>\d{2})',
-        r'^cfme-nightly-(?P<ver>59\d+)-(?P<year>\d{4})?(?P<month>\d{2})(?P<day>\d{2})',
-        r'^cfme-(?P<ver>59\d+)-(?P<month>\d{2})(?P<day>\d{2})',
-        r'^docker-(?P<ver>59\d+)-(?P<year>\d{4})?(?P<month>\d{2})(?P<day>\d{2})',
-        r'^s(-|_)(appl|tpl)(-|_)downstream(-|_)(?P<ver>59)z(-|_)(?P<year>\d{2})?'
-        r'(?P<month>\d{2})(?P<day>\d{2})']),
-    '5.10': SPTuple('downstream-510z', '4.7', [
-        r'^cfme-(?P<ver>510\d{3})-(?P<year>\d{4})?(?P<month>\d{2})(?P<day>\d{2})',
-        r'^cfme-(?P<ver>510\d+)-(?P<month>\d{2})(?P<day>\d{2})',
-        r'^docker-(?P<ver>510\d+)-(?P<year>\d{4})?(?P<month>\d{2})(?P<day>\d{2})',
-        r'^s(-|_)(appl|tpl)(-|_)downstream(-|_)(?P<ver>510)z(-|_)(?P<year>\d{2})?'
-        r'(?P<month>\d{2})(?P<day>\d{2})']),
-    'darga': SPTuple('upstream-darga', 'master', [
-        r'^miq-(?P<ver>darga[-\w]*?)-(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2})',
-        r'^miq-stable-(?P<ver>darga[-\w]*?)-(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2})',
-        r'^s(-|_)(appl|tpl)(-|_)upstream(-|_)(?P<ver>darga[-\w]*?)(-|_)'
-        r'(?P<year>\d{2})(?P<month>\d{2})(?P<day>\d{2})']),
-    'euwe': SPTuple('upstream-euwe', 'master', [
-        r'^miq-(?P<ver>euwe[-\w]*?)-(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2})',
-        r'^miq-stable-(?P<ver>euwe[-\w]*?)-(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2})',
-        r'^s(-|_)(appl|tpl)(-|_)upstream(-|_)(?P<ver>euwe[-\w]*?)(-|_)'
-        r'(?P<year>\d{2})(?P<month>\d{2})(?P<day>\d{2})']),
-    'fine': SPTuple('upstream-fine', 'master', [
-        r'^miq-(?P<ver>fine[-\w]*?)-(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2})',
-        r'^miq-stable-(?P<ver>fine[-\w]*?)-(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2})',
-        r'^s(-|_)(appl|tpl)(-|_)upstream(-|_)(?P<ver>fine[-\w]*?)(-|_)'
-        r'(?P<year>\d{2})(?P<month>\d{2})(?P<day>\d{2})']),
-    'gap': SPTuple('upstream-gap', 'master', [
-        r'^miq-(?P<ver>gapri[-\w]*?)-(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2})',
-        r'^miq-stable-(?P<ver>gapri[-\w]*?)-(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2})',
-        r'^s(-|_)(appl|tpl)(-|_)upstream(-|_)(?P<ver>gapri[-\w]*?)(-|_)'
-        r'(?P<year>\d{2})(?P<month>\d{2})(?P<day>\d{2})']),
-    LATEST: SPTuple('upstream', 'master', [
-        r'miq-nightly-(?P<ver>(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2}))',
-        r'miq-(?P<ver>(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2}))',
-        r'^s(-|_)(appl|tpl)(-|_)upstream(-|_)(stable(-|_))?'
-        r'(?P<year>\d{2})(?P<month>\d{2})(?P<day>\d{2})'])
+    '5.2': SPTuple('downstream-52z', '3.0',
+                   [regex.format(major='5', minor='2') for regex in FORMATS_DOWNSTREAM.values()]),
+    '5.3': SPTuple('downstream-53z', '3.1',
+                   [regex.format(major='5', minor='3') for regex in FORMATS_DOWNSTREAM.values()]),
+    '5.4': SPTuple('downstream-54z', '3.2',
+                   [regex.format(major='5', minor='4') for regex in FORMATS_DOWNSTREAM.values()]),
+    '5.5': SPTuple('downstream-55z', '4.0',
+                   [regex.format(major='5', minor='5') for regex in FORMATS_DOWNSTREAM.values()]),
+    '5.6': SPTuple('downstream-56z', '4.1',
+                   [regex.format(major='5', minor='6') for regex in FORMATS_DOWNSTREAM.values()]),
+    '5.7': SPTuple('downstream-57z', '4.2',
+                   [regex.format(major='5', minor='7') for regex in FORMATS_DOWNSTREAM.values()]),
+    '5.8': SPTuple('downstream-58z', '4.5',
+                   [regex.format(major='5', minor='8') for regex in FORMATS_DOWNSTREAM.values()]),
+    '5.9': SPTuple('downstream-59z', '4.6',
+                   [regex.format(major='5', minor='9') for regex in FORMATS_DOWNSTREAM.values()]),
+    '5.10': SPTuple('downstream-510z', '4.7',
+                   [regex.format(major='5', minor='10') for regex in FORMATS_DOWNSTREAM.values()]),
+    'darga': SPTuple('upstream-darga', 'master',
+                   [regex.format(stream='darga') for regex in FORMATS_UPSTREAM.values()]),
+    'euwe': SPTuple('upstream-euwe', 'master',
+                    [regex.format(stream='euwe') for regex in FORMATS_UPSTREAM.values()]),
+    'fine': SPTuple('upstream-fine', 'master',
+                    [regex.format(stream='fine') for regex in FORMATS_UPSTREAM.values()]),
+    'gap': SPTuple('upstream-gap', 'master',
+                   [regex.format(stream='gapri') for regex in FORMATS_UPSTREAM.values()]),
+    LATEST: SPTuple('upstream', 'master',
+                    [r'miq-nightly-(?P<ver>(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2}))',
+                     r'miq-(?P<ver>(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2}))',
+                     r'^s(-|_)(appl|tpl)(-|_)upstream(-|_)(stable(-|_))?'
+                     r'(?P<year>\d{2})(?P<month>\d{2})(?P<day>\d{2})'])
 }
 
 # maps some service templates
@@ -317,16 +295,26 @@ generic_matchers = (
 )
 
 
-def futurecheck(check_date):
-    """Given a date object, return a date object that isn't from the future
+def datecheck(check_date):
+    """Given a date object, return a date object that isn't from the future or distant past
 
     Some templates only have month/day values, not years. We create a date object
+    Some templates have a timestamp that ends up parsing to a yyyymmdd
+        But they were actually HHMMmmdd, like 11221212, dec 12th 11:22 AM, not dec 12 year 1122
+        Make sure the date isn't from future, but is also within the last 10 years
 
     """
     today = date.today()
+    # long ago, or at least start of the millennium
+    if check_date.year < 100:
+        # 2 digit year, add millenia
+        check_date = check_date.replace(year=check_date.year + 2000)
+    elif check_date.year < 2000:
+        # probably parsed wrong from an HHMMmmdd (hour-minute-month-day) timestamp, reset year
+        check_date = check_date.replace(year=today.year)
     while check_date > today:
+        # keep walking back, don't just set year, because month/day might be later in the year
         check_date = date(check_date.year - 1, check_date.month, check_date.day)
-
     return check_date
 
 
@@ -361,6 +349,8 @@ class TemplateName(object):
     CFME_ID = 'cfme'
     MIQ_ID = 'manageiq'
     build_url = attr.ib()  # URL to the build folder with ova/vhd/qc2/etc images
+    # specific image URL, when set the template name will include build type info, like paravirtual
+    image_url = attr.ib(default=None)
 
     @property
     def build_version(self):
@@ -377,14 +367,15 @@ class TemplateName(object):
         """
         v = requests.get('/'.join([self.build_url, 'version']))
         if v.ok:
+            # split and reform version string to be explicit and verbose+
             match = re.search(
-                '^(?P<major>\d)\.?(?P<minor>\d)\.?(?P<patch>\d)\.?(?P<build>\d{1,2})',
+                '^(?P<major>\d)\.(?P<minor>\d{1,2})\.(?P<patch>\d{1,2})\.(?P<build>\d{1,2})',
                 v.content)
             if match:
-                return ''.join([match.group('major'),
-                                match.group('minor'),
-                                match.group('patch'),
-                                match.group('build').zfill(2)])  # zero left-pad
+                return '.'.join([match.group('major'),
+                                 match.group('minor'),
+                                 match.group('patch'),
+                                 match.group('build')])
             else:
                 raise ValueError('Unable to match version string in %s/version: {}'
                                  .format(self.build_url, v.content))
@@ -426,11 +417,32 @@ class TemplateName(object):
             raise ValueError('{} file not found in {}'.format(self.SHA, self.build_url))
 
     @property
+    def build_type(self):
+        """Get a specific template type from the image URL
+        Used for things like vpshere where there is separate paravirtual image
+        Or rhv, where there are ova and qcow2 images
+
+        Only set if a specific image url was supplied for the object, not applicable when looking at
+        an entire build directory of images.
+        """
+        if not self.image_url:
+            return None
+        elif 'paravirtual' in self.image_url:
+            return 'pv'
+        else:
+            return self.image_url.split('.')[-1]  # file type
+
+    @property
     def template_name(self):
         """Actually construct the template name"""
-        return '-'.join([self.CFME_ID if self.CFME_ID in self.build_url else self.MIQ_ID,
-                         self.build_version,
-                         self.build_date])
+        name_args = [self.CFME_ID if self.CFME_ID in self.build_url else self.MIQ_ID,
+                     self.build_version]
+        bt = self.build_type
+        if bt:
+            name_args.append(bt)
+        name_args.append(self.build_date)
+
+        return '-'.join(name_args)
 
     @classmethod
     def parse_template(cls, template_name):
@@ -452,34 +464,23 @@ class TemplateName(object):
                     year = int(groups.get('year', today.year) or today.year)
                     month, day = int(groups['month']), int(groups['day'])
                     version = groups.get('ver')
+                    # strip - in case regex includes them, replace empty string with None
+                    temp_type = groups.get('type') or None
                     # validate the template date by turning into a date obj
                     try:
                         # year, month, day might have been parsed incorrectly with loose regex
-                        template_date = futurecheck(date(year, month, day))
+                        template_date = datecheck(date(year, month, day))
                     except ValueError:
                         continue
-                    if 'downstream' not in stream_tuple.stream:
-                        dot_version = version
-                    elif version.startswith('51'):
-                        version = version.ljust(4, '0')
-                        dot_version = '{}.{}.{}.{}'.format(version[0],
-                                                           version[1:3],
-                                                           version[3],
-                                                           version[4:])
-                    else:
-                        version = version.ljust(4, '0')
-                        dot_version = '{}.{}.{}.{}'.format(version[0],
-                                                           version[1],
-                                                           version[2],
-                                                           version[3:])
 
                     return TemplateInfo(stream_tuple.stream,
                                         template_date,
                                         True,
-                                        version=dot_version)
+                                        version,
+                                        temp_type)
         for group_name, regex in generic_matchers:
             matches = re.match(regex, template_name)
             if matches:
-                return TemplateInfo(group_name, None, False, None)
+                return TemplateInfo(group_name, None, False, None, None)
         # If no match, unknown
-        return TemplateInfo('unknown', None, False, None)
+        return TemplateInfo('unknown', None, False, None, None)

--- a/miq_version/__init__.py
+++ b/miq_version/__init__.py
@@ -464,6 +464,21 @@ class TemplateName(object):
                     year = int(groups.get('year', today.year) or today.year)
                     month, day = int(groups['month']), int(groups['day'])
                     version = groups.get('ver')
+                    if ('.' not in version and  # the version in the template wasn't dotted
+                            'downstream' in stream_tuple.stream and  # don't try to parse upstream
+                            len(version) > 3):  # sprout templates only have stream
+                        # old template name format with no dots
+                        if version.startswith('51'):
+                            version = '{}.{}.{}.{}'.format(version[0],
+                                                           version[1:3],
+                                                           version[3],
+                                                           version[4:])
+                        else:
+                            version = '{}.{}.{}.{}'.format(version[0],
+                                                           version[1],
+                                                           version[2],
+                                                           version[3:])
+
                     # strip - in case regex includes them, replace empty string with None
                     temp_type = groups.get('type') or None
                     # validate the template date by turning into a date obj

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,8 @@
 attrs
 cached_property
+deepdiff
 lxml
 requests
 six
+oslo.i18n
+pytest

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -136,6 +136,10 @@ def test_version_list():
 # namedtuple('TemplateInfo', ['group_name', 'datestamp', 'stream', 'version', 'type'])
 @pytest.mark.parametrize(
     ('tmp_name', 'info_tuple'), [
+        ('cfme-51006-07252250',  # older format
+         TemplateInfo('downstream-510z', date(2018, 7, 25), True, '5.10.0.6', None)),
+        ('cfme-59410-04132250',  # older format, might break eventually because of year not present
+         TemplateInfo('downstream-59z', date(2018, 4, 13), True, '5.9.4.10', None)),
         ('miq-nightly-20180531',
          TemplateInfo('upstream', date(2018, 5, 31), True, '20180531', None)),
         ('miq-darga-20151009',
@@ -169,7 +173,7 @@ def test_version_list():
         ('cfme-5.9.4.1-qcow2-20180224',
          TemplateInfo('downstream-59z', date(2018, 2, 24), True, '5.9.4.1', 'qcow2')),
         ('docker-59410-20180606',
-         TemplateInfo('downstream-59z', date(2018, 6, 6), True, '59410', None)),
+         TemplateInfo('downstream-59z', date(2018, 6, 6), True, '5.9.4.10', None)),
         ('docker-5.9.4.10-20180606',
          TemplateInfo('downstream-59z', date(2018, 6, 6), True, '5.9.4.10', None)),
         ('s_tpl_downstream-510z_180621_nBAFLQ8A',

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,7 +1,12 @@
 # -*- coding: utf-8 -*-
 import pytest
+from datetime import date
 
-from miq_version import Version, TemplateName
+from deepdiff import DeepDiff
+
+from miq_version import Version, TemplateName, datecheck, TemplateInfo
+
+TODAY = date.today()
 
 version_list = [
     Version('5.7.0.0'),
@@ -128,9 +133,83 @@ def test_version_list():
     assert sorted(version_list, reverse=True) == reverse_sorted_version
 
 
-@pytest.mark.parametrize(('tmp_name', 'ver_string'),
-                         [('miq-nightly-20180531', '20180531'),
-                          ('miq-fine-3-20171215', 'fine-3'),
-                          ('cfme-58403-20180220', '5.8.4.03')])
-def test_template_parsing(tmp_name, ver_string):
-    assert TemplateName.parse_template(tmp_name).version == ver_string
+# namedtuple('TemplateInfo', ['group_name', 'datestamp', 'stream', 'version', 'type'])
+@pytest.mark.parametrize(
+    ('tmp_name', 'info_tuple'), [
+        ('miq-nightly-20180531',
+         TemplateInfo('upstream', date(2018, 5, 31), True, '20180531', None)),
+        ('miq-darga-20151009',
+         TemplateInfo('upstream-darga', date(2015, 10, 9), True, 'darga', None)),
+        ('miq-euwe-20161028',
+         TemplateInfo('upstream-euwe', date(2016, 10, 28), True, 'euwe', None)),
+        ('miq-fine-3-20171215',
+         TemplateInfo('upstream-fine', date(2017, 12, 15), True, 'fine-3', None)),
+        ('miq-gapri-20180411',
+         TemplateInfo('upstream-gap', date(2018, 4, 11), True, 'gapri', None)),
+        ('cfme-5.2.5.3-20180213',
+         TemplateInfo('downstream-52z', date(2018, 2, 13), True, '5.2.5.3', None)),
+        ('cfme-5.3.5.03-20180213',
+         TemplateInfo('downstream-53z', date(2018, 2, 13), True, '5.3.5.03', None)),
+        ('cfme-5.4.5.3-20180213',
+         TemplateInfo('downstream-54z', date(2018, 2, 13), True, '5.4.5.3', None)),
+        ('cfme-5.5.5.3-20180213',
+         TemplateInfo('downstream-55z', date(2018, 2, 13), True, '5.5.5.3', None)),
+        ('cfme-5.6.5.3-20180213',
+         TemplateInfo('downstream-56z', date(2018, 2, 13), True, '5.6.5.3', None)),
+        ('cfme-5.7.5.3-20180213',
+         TemplateInfo('downstream-57z', date(2018, 2, 13), True, '5.7.5.3', None)),
+        ('cfme-5.8.4.3-20180220',
+         TemplateInfo('downstream-58z', date(2018, 2, 20), True, '5.8.4.3', None)),
+        ('cfme-5.10.0.3-20180221',
+         TemplateInfo('downstream-510z', date(2018, 2, 21), True, '5.10.0.3', None)),
+        ('cfme-5.10.1.10-20180222',
+         TemplateInfo('downstream-510z', date(2018, 2, 22), True, '5.10.1.10', None)),
+        ('cfme-5.9.3.10-pv-20180223',
+         TemplateInfo('downstream-59z', date(2018, 2, 23), True, '5.9.3.10', 'pv')),
+        ('cfme-5.9.4.1-qcow2-20180224',
+         TemplateInfo('downstream-59z', date(2018, 2, 24), True, '5.9.4.1', 'qcow2')),
+        ('docker-59410-20180606',
+         TemplateInfo('downstream-59z', date(2018, 6, 6), True, '59410', None)),
+        ('docker-5.9.4.10-20180606',
+         TemplateInfo('downstream-59z', date(2018, 6, 6), True, '5.9.4.10', None)),
+        ('s_tpl_downstream-510z_180621_nBAFLQ8A',
+         TemplateInfo('downstream-510z', date(2018, 6, 21), True, '510', None))]
+)
+def test_template_parsing(tmp_name, info_tuple):
+    parsed = TemplateName.parse_template(tmp_name)
+    print('template name: {}'.format(tmp_name))
+    print('Parsed template: {}'.format(parsed))
+    print('expected: {}'.format(info_tuple))
+    diff = DeepDiff(parsed, info_tuple,
+                    verbose_level=0,  # If any higher, will flag string vs unicode
+                    ignore_order=False)
+    assert diff == {}
+
+
+@pytest.mark.parametrize(
+    ('image_url', 'expected_type'),
+    [('http://domain.example.com/build/folder/path/cfme-5.9.1.1-paravirtual.ova', 'pv'),
+     ('http://domain.example.com/build/folder/path/cfme-5.9.1.1.qcow2', 'qcow2')])
+def test_template_build_type(image_url, expected_type):
+    """test the build_type parameter of TemplateName class
+
+    Bogus build_url, only image_url is used for this property
+
+    TODO: mock requests for testing other parameters of TemplateName
+    """
+    t = TemplateName(build_url='http://fake.example.com', image_url=image_url)
+    assert t.build_type == expected_type
+
+
+@pytest.mark.parametrize(
+    ('test_date', 'expected_date'),
+    [(date(2018, 1, 1), date(2018, 1, 1)),
+     (date(2000, TODAY.month, TODAY.day), date(2000, TODAY.month, TODAY.day)),  # past, no modify
+     (date(1999, TODAY.month, TODAY.day), date(2018, TODAY.month, TODAY.day)),  # past, modified
+     (date(16, TODAY.month, TODAY.day), date(2016, TODAY.month, TODAY.day)),  # short year
+     (date(30, TODAY.month, TODAY.day), date(2018, TODAY.month, TODAY.day)),  # short year, future
+     (date(1130, TODAY.month, TODAY.day), date(TODAY.year, TODAY.month, TODAY.day)),  # bad parse
+     (date(2019, TODAY.month, TODAY.day), date(2018, TODAY.month, TODAY.day)),  # future, 1 year
+     (date(2030, TODAY.month, TODAY.day), date(2018, TODAY.month, TODAY.day))])  # future, iterate
+def test_datecheck(test_date, expected_date):
+    assert expected_date == datecheck(test_date)


### PR DESCRIPTION
A few updates:

1. build_type support with an image_url attribute for a specific image, not a build directory
2. `futurecheck()` changed to `datecheck()` because now it looks for dates before 1900, as those don't work with datetime.strftime and its nonsensical for the use case.  Also handles 2 digit years from some of the sprout expressions, as those don't format out correctly either.
3. condensing the regex expressions, could be further collapsed into a giant generator with some zips, but not trying to make it quite _that_ heavy.
4. refactored the `TemplateName.parse_template` test with a bunch of new parametrizations
5. added new tests for new/refactored methods