### PR TITLE
deepdiff v3.3.0 last version for py2 support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 attrs
 cached_property
-deepdiff
+# DeepDiff v3.3.0 is the last version to supprt py2
+deepdiff<=3.3.0
 lxml
 requests
 six


### PR DESCRIPTION
Signed-off-by: Nikhil Dhandre <ndhandre@redhat.com>