### PR TITLE
Update upstream names

### DIFF
--- a/miq_version/__init__.py
+++ b/miq_version/__init__.py
@@ -35,19 +35,11 @@ class Version(object):
         elif vstring:
             vstring = str(vstring).strip()
         # TODO separate upstream versions
-        if any([
-                vstring in ('master', 'latest', 'upstream'),
-                'fine' in vstring,
-                'euwe' in vstring,
-                'gaprindashvili' in vstring]):
+        if vstring in ('master', 'latest', 'upstream'):
             vstring = 'master'
-        # TODO These aren't used anywhere - remove?
-        if vstring == 'darga-3':
-            vstring = '5.6.1'
-        if vstring == 'darga-4.1':
-            vstring = '5.6.2'
-        if vstring == 'darga-5':
-            vstring = '5.6.3'
+        for upstream_series in ['fine', 'euwe', 'gaprindashvili']:
+            if upstream_series in vstring:
+                vstring = upstream_series
 
         components = list(filter(lambda x: x and x != '.',
                             self.component_re.findall(vstring)))

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -133,6 +133,18 @@ def test_version_list():
     assert sorted(version_list, reverse=True) == reverse_sorted_version
 
 
+@pytest.mark.parametrize(('version', 'series', 'stream'), [
+    ('master', 'master', 'upstream'),
+    ('euwe', 'euwe', 'upstream-euwe'),
+    ('fine', 'fine', 'upstream-fine'),
+    ('5.10.0.0', '5.10', 'downstream-510z'),
+    ('5.11.0.0', '5.11', 'downstream-511z'),
+])
+def test_version_series_stream(version, series, stream):
+    assert Version(version).is_in_series(series)
+    assert Version(version).stream() == stream
+
+
 # namedtuple('TemplateInfo', ['group_name', 'datestamp', 'stream', 'version', 'type'])
 @pytest.mark.parametrize(
     ('tmp_name', 'info_tuple'), [


### PR DESCRIPTION
Fix a bug in stream names for upstream templates.

Wrote a unit test to replicate the failure, if you run that test without the other commit it will fail and incorrectly identify the stream for some upstream version strings.